### PR TITLE
fix typescript type import compliance

### DIFF
--- a/src/components/JsonTreeView.vue
+++ b/src/components/JsonTreeView.vue
@@ -8,12 +8,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, SetupContext } from "vue";
+import { computed, defineComponent, type SetupContext } from "vue";
 
 import JsonTreeViewItem, {
   ItemType,
-  ValueTypes,
-  ItemData,
+  type ValueTypes,
+  type ItemData,
 } from "./JsonTreeViewItem.vue";
 
 type Props = {

--- a/src/components/JsonTreeViewItem.vue
+++ b/src/components/JsonTreeViewItem.vue
@@ -41,9 +41,9 @@
 import {
   computed,
   defineComponent,
-  PropType,
+  type PropType,
   reactive,
-  SetupContext,
+  type SetupContext,
 } from "vue";
 import { then, when } from "switch-ts";
 


### PR DESCRIPTION
plugin is broken when using newer versions of typescript if type imports are enforced.