### PR TITLE
Use correct type for onClick event

### DIFF
--- a/src/components/JsonTreeViewItem.vue
+++ b/src/components/JsonTreeViewItem.vue
@@ -114,7 +114,7 @@ export default defineComponent({
       state.open = !state.open;
     }
 
-    function onClick(data: Data): void {
+    function onClick(data: ItemData): void {
       context.emit("selected", {
         key: data.key,
         value: data.value,


### PR DESCRIPTION
Resolves type error `Argument of type 'ItemData' is not assignable to parameter of type 'Data'.`