### PR TITLE
ci: align OIDC publish config with switch-ts

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -114,7 +114,9 @@ jobs:
         with:
           node-version-file: .node-version
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          # OIDC release job: disable setup-node's package-manager cache (npm
+          # trusted-publishing best practice - avoid caching credentials).
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -146,6 +148,11 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          # setup-node v6.4.0 injects a dummy NODE_AUTH_TOKEN when registry-url
+          # is set; force it empty so a failed OIDC exchange surfaces as a clean
+          # ENEEDAUTH rather than a confusing E404. On success npm uses the OIDC
+          # token regardless.
+          NODE_AUTH_TOKEN: ''
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
## Summary

- Align the publish workflow with `switch-ts` for consistency across the sibling toolchain repos.
- Publish-job `setup-node`: `cache: pnpm` → `package-manager-cache: false` (npm trusted-publishing best practice — do not cache credentials in a release job).
- Publish step: set `NODE_AUTH_TOKEN: ''`. `actions/setup-node@v6.4.0` injects a dummy `NODE_AUTH_TOKEN` when `registry-url` is set; forcing it empty makes a failed OIDC exchange surface as a clean `ENEEDAUTH` instead of a confusing `E404`. On a successful exchange npm uses the OIDC token regardless (this repo already published 2.0.0 via OIDC without this change).\n\nCI-only change; the test job keeps caching.