### PR TITLE
ci: limit push trigger to main to stop duplicate runs

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -2,7 +2,9 @@ name: Browser Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -2,6 +2,7 @@ name: Node.js CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Restrict the `push` trigger of both CI workflows to `main`, so each pull request runs CI once instead of twice.

## Problem

`npm-ci.yml` and `browser-tests.yml` both trigger on `push` with no branch
filter while also triggering on `pull_request`. Every pull request therefore ran
the full build and browser test matrix twice against the same commit.

Unlike the sibling `google-map-ts-vue3` repository, neither workflow here
declares a `concurrency` group, so the duplicate runs did not cancel each other
and no checks were falsely reported as failing. The cost is purely wasted CI
minutes.

## Changes

### Fixed

- `.github/workflows/npm-ci.yml`: `on.push` limited to `main`
- `.github/workflows/browser-tests.yml`: `on.push` and `on.pull_request` limited to `main`

## Test Plan

- [x] Both files parse as valid YAML and resolve to `{push: {branches: [main]}, pull_request: {branches: [main]}}`
- [ ] CI on this pull request produces exactly one `Node.js CI` run and one `Browser Tests` run